### PR TITLE
Fix race with timer interrupt 1

### DIFF
--- a/main.c
+++ b/main.c
@@ -252,8 +252,6 @@ void main()
 
 					PrevButtons = Buttons;
 				}
-
-				P3 ^= 0b01000000;
 			}
 		}
 #endif


### PR DESCRIPTION
I'm not sure what this line was supposed to do. Maybe leftover from debugging?
However I found that it is causing sporadic incorrect PS/2 mouse events for my HIDman AXP
Doesn't happen when with timer interrupt 1 disabled around this line.
I'm assuming that this is a race-condition of this read-modify-write operation with the interrupt handler that is transmitting PS/2 mouse data and modifies P3.7 (clock).