### PR TITLE
Implemented support for PS/2 mouse data reporting enable / disable.

### DIFF
--- a/mouse.c
+++ b/mouse.c
@@ -23,6 +23,7 @@ MOUSE OutputMice[2];
 void InitMice()
 {
     memset(OutputMice, 0x00, sizeof(OutputMice));
+	Ps2MouseSetDefaults();
 }
 uint8_t updates = 0;
 void MouseMove(int16_t DeltaX, int16_t DeltaY)
@@ -39,8 +40,13 @@ void MouseMove(int16_t DeltaX, int16_t DeltaY)
 uint8_t GetMouseUpdate(uint8_t MouseNo, int16_t Min, int16_t Max, int16_t *X, int16_t *Y, uint8_t *Buttons)
 {
     MOUSE *m = &OutputMice[MouseNo];
-
-    if (m->NeedsUpdating)
+	
+	if (MouseNo == MOUSE_PORT_PS2 && m->Ps2DataReporting == MOUSE_PS2_REPORTING_OFF)
+	{
+		// ps2 mouse and data reporting is off - no matter if update is needed or not, we do not give one
+		return 0;
+	}
+    else if (m->NeedsUpdating)
     {
         // Assume it doesn't need updating after this
         m->NeedsUpdating = 0;
@@ -120,3 +126,52 @@ void MouseSet(uint8_t Button, uint8_t value)
         m->NeedsUpdating = 1;
     }
 }
+
+void Ps2MouseSetXY(uint8_t DeltaX, uint8_t DeltaY)
+{
+	MOUSE *m = &OutputMice[MOUSE_PORT_PS2];
+	m->DeltaX = DeltaX;
+	m->DeltaY = DeltaY;
+}
+
+void Ps2MouseSetMode(uint8_t Mode) {
+	// TODO: implement (does anything use remote or wrap mode?)
+	MOUSE *m = &OutputMice[MOUSE_PORT_PS2];
+	m->Ps2Mode = Mode;
+	Ps2MouseSetXY(0, 0);
+}
+
+void Ps2MouseSetRate(uint8_t Rate) {
+	// TODO: implement
+	MOUSE *m = &OutputMice[MOUSE_PORT_PS2];
+	m->Ps2Rate = Rate;
+	Ps2MouseSetXY(0, 0);
+}
+
+void Ps2MouseSetResolution(uint8_t Resolution) {
+	// TODO: implement
+	MOUSE *m = &OutputMice[MOUSE_PORT_PS2];
+	m->Ps2Resolution = Resolution;
+	Ps2MouseSetXY(0, 0);
+}
+
+void Ps2MouseSetScaling(uint8_t Scaling) {
+	// TODO: implement
+	MOUSE *m = &OutputMice[MOUSE_PORT_PS2];
+	m->Ps2Scaling = Scaling;
+}
+
+void Ps2MouseSetReporting(bool Reporting) {
+	MOUSE *m = &OutputMice[MOUSE_PORT_PS2];
+	m->Ps2DataReporting = Reporting;
+	//m->NeedsUpdating = 1; // looks like some mouse drivers will hang until first update is sent  
+	Ps2MouseSetXY(0, 0);
+}
+
+void Ps2MouseSetDefaults() {
+	Ps2MouseSetRate(100);
+	Ps2MouseSetResolution(MOUSE_PS2_RESOLUTION_4CMM);
+	Ps2MouseSetScaling(MOUSE_PS2_SCALING_1X);
+	Ps2MouseSetReporting(MOUSE_PS2_REPORTING_OFF);
+	Ps2MouseSetMode(MOUSE_PS2_MODE_STREAM);
+} 

--- a/mouse.h
+++ b/mouse.h
@@ -6,6 +6,22 @@
 #define MOUSE_PORT_SERIAL 1
 #define MOUSE_PORT_QUADRATURE 2 //or whatever
 
+#define MOUSE_PS2_MODE_STREAM 0
+#define MOUSE_PS2_MODE_REMOTE 1
+#define MOUSE_PS2_MODE_WRAP 2
+#define MOUSE_PS2_MODE_RESET 3
+
+#define MOUSE_PS2_RESOLUTION_1CMM 1
+#define MOUSE_PS2_RESOLUTION_2CMM 2
+#define MOUSE_PS2_RESOLUTION_4CMM 4
+#define MOUSE_PS2_RESOLUTION_8CMM 8
+
+#define MOUSE_PS2_SCALING_1X 0
+#define MOUSE_PS2_SCALING_2X 1
+
+#define MOUSE_PS2_REPORTING_OFF 0
+#define MOUSE_PS2_REPORTING_ON 1
+
 typedef struct MOUSE {
 
     // the accumulated X and Y movements
@@ -20,6 +36,13 @@ typedef struct MOUSE {
     // set by USB HID processing, cleared by output
     bool NeedsUpdating;
 
+	// ps2 port registers (not relevant for serial port) 
+	uint8_t Ps2Mode;
+	uint8_t Ps2Rate;
+	uint8_t Ps2Resolution;
+	uint8_t Ps2Scaling;
+	uint8_t Ps2DataReporting;
+	
 } MOUSE;
 
 void InitMice();
@@ -28,4 +51,13 @@ uint8_t GetMouseUpdate(uint8_t MouseNo, int16_t Min, int16_t Max, int16_t *X, in
 void MouseClick(uint8_t Button);
 void MouseUnclick(uint8_t Button);
 void MouseSet(uint8_t Button, uint8_t value);
+
+void Ps2MouseSetXY(uint8_t X, uint8_t Y);
+void Ps2MouseSetMode(uint8_t Mode);
+void Ps2MouseSetRate(uint8_t Rate);
+void Ps2MouseSetResolution(uint8_t Resolution);
+void Ps2MouseSetScaling(uint8_t Scaling);
+void Ps2MouseSetReporting(bool Reporting);
+void Ps2MouseSetDefaults(); 
+
 #endif

--- a/ps2protocol.c
+++ b/ps2protocol.c
@@ -526,6 +526,7 @@ void HandleReceived(uint8_t port)
 			switch (ports[port].recvout)
 			{
 			case 0xE9:							// Status Request
+				// TODO: construct bytes 2 and 3 from real state
 				SimonSaysSendMouse1(0xFA);		// ACK
 				SimonSaysSendMouse3(0b00100000, // Stream Mode, Scaling 1:1, Enabled, No buttons pressed
 									0x02,		// Resolution 4 counts/mm
@@ -538,14 +539,34 @@ void HandleReceived(uint8_t port)
 				SimonSaysSendMouse1(0x00); // Standard mouse
 				break;
 
+			// Enable Reporting
+			case 0xF4: 
+				SimonSaysSendMouse1(0xFA); // ACK
+				Ps2MouseSetReporting(MOUSE_PS2_REPORTING_ON);
+				break; 
+				
+			// Disable Reporting
+			case 0xF5: 
+				SimonSaysSendMouse1(0xFA); // ACK
+				Ps2MouseSetReporting(MOUSE_PS2_REPORTING_OFF);
+				break;
+			
+			// Set Defaults
+			case 0xF6: 
+				SimonSaysSendMouse1(0xFA); // ACK
+				Ps2MouseSetDefaults();
+				break;
+			
 			// Reset
 			case 0xFF:
 				SimonSaysSendMouse1(0xFA); // ACK
 				SimonSaysSendMouse1(0xAA); // POST OK
 				SimonSaysSendMouse1(0x00); // Squeek Squeek I'm a mouse
+				Ps2MouseSetDefaults();
 				break;
 
 			// unimplemented command
+			// TODO: implement, we already have some functions in mouse.c
 			case 0xE6: // Set Scaling 1:1
 			case 0xE7: // Set Scaling 2:1
 			case 0xE8: // Set Resolution
@@ -555,9 +576,6 @@ void HandleReceived(uint8_t port)
 			case 0xEE: // Set Wrap Mode
 			case 0xF0: // Remote Mode
 			case 0xF3: // Set Sample Rate
-			case 0xF4: // Enable Reporting
-			case 0xF5: // Disable Reporting
-			case 0xF6: // Set Defaults
 			case 0xFE: // Resend
 			default:   // argument from command?
 


### PR DESCRIPTION
Data reporting support does fix problem where certain PS/2 controllers will disable mouse port on POST if mouse is transmitting anhything while data reporting is off.

There are also stub functions for implementing scaling / resolution etc, but not implemented yet.