### PR TITLE
Fix compatibility with HIDman-mini and HIDman-micro

### DIFF
--- a/firmware/build-release.bat
+++ b/firmware/build-release.bat
@@ -1,0 +1,21 @@
+mkdir release
+
+make clean
+make TARGET=HIDman-axp_v1.1.3 BOARD_TYPE=BOARD_AXP
+cp ./build/HIDman-axp_v1.1.3.bin ./release
+
+make clean
+make TARGET=HIDman-mini_serial_v1.1.3 BOARD_TYPE=BOARD_AXP OSC_TYPE=OSC_INTERNAL
+cp ./build/HIDman-mini_serial_v1.1.3.bin ./release
+
+make clean
+make TARGET=HIDman-mini_v1.1.3 BOARD_TYPE=BOARD_MINI OSC_TYPE=OSC_INTERNAL
+cp ./build/HIDman-mini_v1.1.3.bin ./release
+
+make clean
+make TARGET=HIDman-micro_v1.1.3 BOARD_TYPE=BOARD_MICRO OSC_TYPE=OSC_INTERNAL
+cp ./build/HIDman-micro_v1.1.3.bin ./release
+
+make clean
+make TARGET=HIDman-micro_swapped_v1.1.3 BOARD_TYPE=BOARD_MICRO BOARD_OPTIONS=OPT_SWAP_KBD_MSC OSC_TYPE=OSC_INTERNAL
+cp ./build/HIDman-micro_swapped_v1.1.3.bin ./release

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -78,7 +78,7 @@ void EveryMillisecond(void) {
 		LEDDelayMs--;
 	} else {
 #if defined(BOARD_MICRO)
-		P2 |= 0b00100000;
+		SetPWM2Dat(0x10);
 #elif defined (BOARD_PS2)
 		P0 |= 0b01110000;
 

--- a/firmware/ps2.h
+++ b/firmware/ps2.h
@@ -15,14 +15,20 @@ void InitPS2Ports();
 
 #if defined(BOARD_MICRO)        // Pinouts for HIDman-micro
 	SBIT(KEY_CLOCK, 0x90, 7);
+	SBIT(KEYAUX_CLOCK, 0x90, 7);
 	#if defined(OPT_SWAP_KBD_MSC) // Makes it easier to direct solder combo PS/2 port
 		SBIT(KEY_DATA, 0x90, 6);
+		SBIT(KEYAUX_DATA, 0x90, 6);
 		SBIT(MOUSE_CLOCK, 0x90, 4);
+		SBIT(MOUSEAUX_CLOCK, 0x90, 4);
 	#else
 		SBIT(KEY_DATA, 0x90, 4);
+		SBIT(KEYAUX_DATA, 0x90, 4);
 		SBIT(MOUSE_CLOCK, 0x90, 6);
+		SBIT(MOUSEAUX_CLOCK, 0x90, 6);
 	#endif
 	SBIT(MOUSE_DATA, 0x90, 5);
+	SBIT(MOUSEAUX_DATA, 0x90, 5);
 #elif defined(BOARD_PS2)
 	SBIT(KEY_CLOCK, 0xB0, 4);
 	SBIT(KEY_DATA, 0xB0, 5);

--- a/firmware/ps2.h
+++ b/firmware/ps2.h
@@ -171,7 +171,7 @@ void PS2ProcessPort(uint8_t port);
 
 
 
-#if defined(BOARD_AXP)
+#if defined(BOARD_AXP) || defined(BOARD_MINI)
 //P4 dir should be 1 (output) when low, 0 (input) when high
 #define WritePS2Data(port, val)     \
 	if (port == PORT_KEY){        \

--- a/firmware/ps2protocol.c
+++ b/firmware/ps2protocol.c
@@ -320,7 +320,7 @@ bool ParseReport(INTERFACE *interface, uint32_t len, uint8_t *report)
 
 	// Turn off LEDs for a while
 #if defined(BOARD_MICRO)
-	P2 &= ~0b00100000;
+	SetPWM2Dat(0x00);
 #elif defined(BOARD_PS2)
 	P0 |= 0b01110000;
 #else

--- a/firmware/system.c
+++ b/firmware/system.c
@@ -113,8 +113,13 @@ void	mDelaymS( UINT16 n )                                                  // ï¿
 	SoftWatchdog = 0;
 }
 
-
-
+#if defined(BOARD_MICRO)
+// HIDman-micro doesn't have Serial port, so use dummy putchar function
+int putchar(int c)
+{
+    return c;
+}
+#endif
 
 
 void GPIOInit(void){
@@ -122,7 +127,7 @@ void GPIOInit(void){
 #if defined(BOARD_MICRO) // Pinouts for HIDman-micro
 	//port1 setup
 	P1_DIR = 0b11110000; // 0.4, 0.5, 0.6, 0.7 are keyboard/mouse outputs
-	PORT_CFG |= bP1_OC;	  // open collector
+	PORT_CFG = bP1_OC;	  // open collector
 	P1_PU = 0x00;		  // no pullups
 	P1 = 0b11110000;	  // default pin states
 

--- a/firmware/system.c
+++ b/firmware/system.c
@@ -137,6 +137,11 @@ void GPIOInit(void){
 	P2_PU = 0x00;		  // no pullups
 	P2 = 0b00100000;	  // LED off by default (i.e. high)
 
+	//port4 setup
+	P4_DIR = 0b00000000; // 4.6 is SWITCH
+	P4_PU = 0b01000000;	 // pullup on switch
+	P4_OUT = 0b00000000;
+
 #elif defined(BOARD_PS2) // Pinouts for old PS2 version
 
 	//port0 setup


### PR DESCRIPTION
Recent changes have broken a few things with the HIDman-mini and HIDman-micro hardware boards.
This PR makes them work properly again.

`OSC_TYPE=OSC_INTERNAL` will be needed for both boards as they do not have an external crystal.
`BOARD_TYPE=BOARD_AXP` works with the mini and enables support for the serial mouse.  Otherwise use `BOARD_TYPE=BOARD_MINI` for a build with just ps/2 support.
`BOARD_TYPE=BOARD_MICRO` is needed for the micro board.

I have no idea if the newly added support for XT and/or Amstrad systems works, as I don't have these systems to test with.